### PR TITLE
Updated instructions to include docker pull before running the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,49 @@ For running the [Softcover](https://github.com/softcover/softcover) eBook typese
 
 Image hosted on [DockerHub](https://hub.docker.com/r/softcover/softcover).
 
-## Usage:
+
+## Usage
+
+The first step is to download the docker image using the commend:
+```bash
+docker pull softcover/softcover
+```
+Note this step takes a long time since we it downloads more than 3GB of files
+(a complete LaTeX distribution, Inkscape, and a complete Ruby dev environment).
+
 
 Build html from book directory:
 ```bash
 docker run -v `pwd`:/book softcover:latest sc build:html
 ```
 
-Run server:
+Run softcover interactive server:
 ```bash
 docker run -v `pwd`:/book -d -p 4000:4000 softcover:latest sc server
 ```
+then open the URL http://localhost:4000/your-book-name.html in your browser.
+
+
+
+## Interactive shell
+
+To run bash inside the container use the following command:
+```bash
+docker run -ti -v `pwd`:/book -p 4000:4000 softcover:latest /bin/bash
+```
+The current working directory is mounted as `/book`.
+
+
+
+## Local docker image build
+
+As an alternative to `docker pull` command above, you can build the docker image
+locally from the provided `Dockerfile`. To build the docker image, run the command
+```bash
+docker build -t softcover-docker .
+```
+This step takes a fairly long time since it downloads a complete TeX distribution
+and other system packages required to run Softcover. Time to go get lunch!
+
+After the docker build step is done, you can run all the commands shown above,
+by replacing the argument `sofcove:latest` with `softcover-docker` (local image tag).

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Note this step takes a long time since we it downloads more than 3GB of files
 
 Build html from book directory:
 ```bash
-docker run -v `pwd`:/book softcover:latest sc build:html
+docker run -v `pwd`:/book softcover/softcover:latest sc build:html
 ```
 
 Run softcover interactive server:
 ```bash
-docker run -v `pwd`:/book -d -p 4000:4000 softcover:latest sc server
+docker run -v `pwd`:/book -d -p 4000:4000 softcover/softcover:latest sc server
 ```
 then open the URL http://localhost:4000/your-book-name.html in your browser.
 
@@ -32,7 +32,7 @@ then open the URL http://localhost:4000/your-book-name.html in your browser.
 
 To run bash inside the container use the following command:
 ```bash
-docker run -ti -v `pwd`:/book -p 4000:4000 softcover:latest /bin/bash
+docker run -ti -v `pwd`:/book -p 4000:4000 softcover/softcover:latest /bin/bash
 ```
 The current working directory is mounted as `/book`.
 
@@ -43,10 +43,10 @@ The current working directory is mounted as `/book`.
 As an alternative to `docker pull` command above, you can build the docker image
 locally from the provided `Dockerfile`. To build the docker image, run the command
 ```bash
-docker build -t softcover-docker .
+docker build -t softcover .
 ```
 This step takes a fairly long time since it downloads a complete TeX distribution
 and other system packages required to run Softcover. Time to go get lunch!
 
 After the docker build step is done, you can run all the commands shown above,
-by replacing the argument `sofcove:latest` with `softcover-docker` (local image tag).
+by replacing the argument `softcover/softcover:latest` with `softcover` (local tag).


### PR DESCRIPTION
 - Resolves https://github.com/softcover/softcover-docker/issues/2
 - Fix info in README (replace `softcover` with `softcover/softcover` as image name
 - Also added info about building image locally from Dockerfile


