### PR TITLE
Use buster-based Docker base image to get latest Inkscape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM circleci/ruby:2.6.3-stretch-node-browsers-legacy
+FROM circleci/ruby:2.6.6-buster-node-browsers-legacy
 MAINTAINER Nick Merwin <nick@softcover.io>
 LABEL company="Softcover, Inc."
-LABEL version="1.0.0"
+LABEL version="1.0.1"
 
 USER root
 
@@ -9,8 +9,11 @@ USER root
 # install deps
 # ==============================================================================
 RUN gem install -v 2.1.4 bundler
-RUN apt-get update -qq && apt-get install -qy --no-install-recommends texlive-full texlive-fonts-recommended \
-  texlive-latex-extra texlive-fonts-extra fonts-gfs-bodoni-classic inkscape ghostscript cabextract
+RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
+RUN apt-get update -qq \
+  && apt-get -t buster-backports install -qy --no-install-recommends "inkscape" \
+  && apt-get install -qy --no-install-recommends texlive-full texlive-fonts-recommended \
+     texlive-latex-extra texlive-fonts-extra fonts-gfs-bodoni-classic ghostscript cabextract
 RUN wget http://ftp.de.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.6_all.deb \
   && dpkg -i ttf-mscorefonts-installer_3.6_all.deb
 RUN wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh


### PR DESCRIPTION
This PR replaces the base image for the Dockerfile from Debian stretch to Debian buster, so that we can get Inkscape from
buster-backports https://packages.debian.org/buster-backports/inkscape (currently inkscape `1.0.1-1~bpo10+1`).

We need the lastest version of Inkscape because the command line argument for "output image" has changed. In the old versions it was `-e` now it is `-o`. Since [this change](https://github.com/minireference/softcover/commit/555a8789d76a0d141c519ad50a6eeb00b62155cf#diff-983d2884d617a1bd7c1ad5e94a50b6a8R364) is already in softcover releases, need to have new Inkscape to build books that contain math.

Output of `git diff --color-words` to better see the change:
<img width="791" alt="Screen Shot 2020-09-28 at 9 06 57 PM" src="https://user-images.githubusercontent.com/163966/94501004-bf576a80-01ce-11eb-94eb-4d78c7b33505.png">


